### PR TITLE
fix: update multimovies stream URL extraction regex

### DIFF
--- a/src/lib/providers/multi/multiGetStream.ts
+++ b/src/lib/providers/multi/multiGetStream.ts
@@ -106,10 +106,11 @@ export const multiGetStream = async (
       console.log('No match found');
     }
 
-    const streamUrl = p?.match(/file:\s*"([^"]+\.m3u8[^"]*)"/)?.[1];
+    const streamUrl = p?.match(/https?:\/\/[^"]+?\.m3u8[^"]*/)?.[0];
     const subtitles: TextTracks = [];
     const subtitleMatch = p?.match(/https:\/\/[^\s"]+\.vtt/g);
     // console.log('subtitleMatch', subtitleMatch);
+    // console.log('streamUrl', streamUrl);
     if (subtitleMatch?.length) {
       subtitleMatch.forEach((sub: any) => {
         const lang = sub.match(/_([a-zA-Z]{3})\.vtt$/)[1];


### PR DESCRIPTION
This pull request includes a small but significant change to the `multiGetStream` function in `src/lib/providers/multi/multiGetStream.ts`. The change modifies the regular expression used to match the stream URL, ensuring it captures the .m3u8 links.

* [`src/lib/providers/multi/multiGetStream.ts`](diffhunk://#diff-0813c5cba9a61f7785b277080810e6132fbc923b8e6210bd18dcb9b6f9d42f6cL109-R113): Updated the regular expression in `streamUrl` to match the .m3u8 links.